### PR TITLE
Added custom message handling

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -112,6 +112,7 @@
     <script src="js/dropmenu.js"></script>
     <script src="js/localstorage.js"></script>
     <script src="js/UIdisableddlg.js"></script>
+    <script src="js/custom.js"></script>
     <!--endRemoveIf(cleanheader)-->
     <!-- smoosh -->
     <script src="js/app.js"></script>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -694,6 +694,9 @@ function process_socket_response(msg) {
         if (msg.startsWith("X:")) {
             process_Position(msg);
         }
+        if (msg.startsWith("esp3d:")) {
+            process_Custom(msg); // handles custom messages sent via M118
+        }
         if (msg.startsWith("ok")) {
             if (socket_is_settings) {
                 //update settings

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -694,7 +694,7 @@ function process_socket_response(msg) {
         if (msg.startsWith("X:")) {
             process_Position(msg);
         }
-        if (msg.startsWith("esp3d:")) {
+        if (msg.startsWith("[esp3d]")) {
             process_Custom(msg); // handles custom messages sent via M118
         }
         if (msg.startsWith("ok")) {

--- a/www/js/custom.js
+++ b/www/js/custom.js
@@ -2,19 +2,29 @@
 // In gcode file, M118 can be used to send messages on serial.
 // This allows the microcontroller to communicate with hosts.
 // Example:
-//   M118 esp3d:<your message>
+//   M118 [esp3d]<your message>
 //      will send "esp3d:<your message>" over serial, which can be picked up by host
 //      to trigger certain actions.
+//   M118 [esp3d]<function call>
+//      will call the function, as long as a handler has been predefined to identify
+//      the call.
 
 function process_Custom(response) {
     var freq = 440;  // beep frequency on end of print
     var dur = 100;  // beep duration on end of print
-    if (response.startsWith("esp3d:eop")) {
+    response = response.replace("[esp3d]","");
+    if (response.startsWith("eop")) {
+        // Example 1
         // Sound to play on end of print
         // Triggered by message on serial terminal
-        // ESP3D:eop
-        //
-        // This message can be sent via M118.
+        // [ESP3D]eop
         beep(dur, freq);
-    }  
+    }
+    if (response.startsWith("beep(")) {
+        // Example 2
+        // Call a function within webUI, in this case beep()
+        // Triggered by message on serial terminal
+        // [ESP3D]beep(100, 261)
+        eval(response);
+    }
 }

--- a/www/js/custom.js
+++ b/www/js/custom.js
@@ -1,0 +1,20 @@
+// Functions to handle custom messages sent via serial.
+// In gcode file, M118 can be used to send messages on serial.
+// This allows the microcontroller to communicate with hosts.
+// Example:
+//   M118 esp3d:<your message>
+//      will send "esp3d:<your message>" over serial, which can be picked up by host
+//      to trigger certain actions.
+
+function process_Custom(response) {
+    var freq = 440;  // beep frequency on end of print
+    var dur = 100;  // beep duration on end of print
+    if (response.startsWith("esp3d:eop")) {
+        // Sound to play on end of print
+        // Triggered by message on serial terminal
+        // ESP3D:eop
+        //
+        // This message can be sent via M118.
+        beep(dur, freq);
+    }  
+}


### PR DESCRIPTION
I added a handler for custom messages. This allows the printer to send custom messages to the webUI via M118. In the "example", when the printer sends `esp3d:eop` on serial, the webUI will beep to signify end of the print. This means a gcode like `M118 esp3d:eop` can be added to the end gcode.

As long as the message starts with `esp3d:`, the function to handle custom messages will be invoked. How the custom message is handled needs to be defined in the `custom.js` file.