### PR TITLE
Fix missing settingid of temperatures panel

### DIFF
--- a/src/components/Panels/Temperatures.js
+++ b/src/components/Panels/Temperatures.js
@@ -384,6 +384,7 @@ const TemperaturesPanelElement = {
     icon: "Thermometer",
     show: "showtemperaturespanel",
     onstart: "opentemperaturesonstart",
+    settingid: "temperatures",
 }
 
 export { TemperaturesPanel, TemperaturesPanelElement, TemperaturesControls }


### PR DESCRIPTION
Without it, the temperature panel is missing when fixed panels order is turned on.