### PR TITLE
Implement optional XY/Z Max Jog distance setting

### DIFF
--- a/src/components/Panels/Jog.js
+++ b/src/components/Panels/Jog.js
@@ -248,7 +248,7 @@ const JogPanel = () => {
             button1: {
                 cb: () => {
                     if (value.length > 0.1)
-                    targetArr[axis] = value
+                        targetArr[axis] = value
                 },
                 text: T("S43"),
                 id: "applyFrBtn",
@@ -495,7 +495,15 @@ const JogPanel = () => {
                                             onCheck(e, 100)
                                         }}
                                     />
-                                    <label for="move_100">100</label>
+                                    <label for="move_100"><span style="padding-left:2px;padding-right:2px;"
+                                        dangerouslySetInnerHTML={{
+                                            __html: 
+                                                ( maxJogDistance["xy"] == maxJogDistance["z"])
+                                                ? (maxJogDistance["xy"] ?? 100)
+                                                : ( maxJogDistance["xy"] + "<sub>xy</sub>&nbsp;" + 
+                                                    maxJogDistance["z"] + "<sub>z</sub>")
+                                        }}
+                                    ></span></label>
                                 </div>
                                 <div
                                     class="flatbtn tooltip tooltip-left"

--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -45,7 +45,7 @@ const keyboardEventHandlerDown = (e) => {
     if (
         document.activeElement &&
         document.activeElement.tagName == "INPUT" &&
-        document.activeElement.type == "text"
+        (document.activeElement.type == "text" || document.activeElement.type == "number")
     ) {
         return
     }

--- a/src/targets/Printer3D/preferences.json
+++ b/src/targets/Printer3D/preferences.json
@@ -291,6 +291,22 @@
                 "value": "1000"
             },
             {
+                "id": "xymaxjog",
+                "type": "number",
+                "label": "P113",
+                "append": "P16",
+                "min": "10",
+                "value": "100"
+            },
+            {
+                "id": "zmaxjog",
+                "type": "number",
+                "label": "P114",
+                "append": "P16",
+                "min": "10",
+                "value": "100"
+            },
+            {
                 "id": "xpos",
                 "type": "number",
                 "label": "P65",

--- a/src/targets/Printer3D/translations/en.json
+++ b/src/targets/Printer3D/translations/en.json
@@ -105,6 +105,8 @@
     "P110": "mins",
     "P111": "secs",
     "P112": "Left",
+    "P113": "XY max jog",
+    "P114": "Z max jog",
     "processing": "Processing",
     "heating": "Heating",
     "controls": "Extra Controls panel",


### PR DESCRIPTION
problem: jogging Z axis 100 on a CNC is recipe for trouble.
cause: Most CNCs have relatively short Z axis.  For example most V1E CNCs have 80mm or shorter Z axis, but may have 1200 x 2400 XY axis.

![image](https://user-images.githubusercontent.com/16479976/211538209-5650b0e4-804b-4648-9825-8146f62924ab.png)

fix: Implement optional "Z Max Jog" distance setting, enabling user to limit maximum Z axis jog distance.  For example 20 makes sense instead of 100mm for Z axis.  To avoid breaking existing behavior, the new _XY Max Jog_ and _Z Max Jog_ distance optional settings default to 100 when not specified.  Not clear who would use "XY Max Jog" setting, but I added anyway for consistency sake.

Thoughts?