### PR TITLE
[DRAFT] Use dosnames in `M23` commands for Marlin

### DIFF
--- a/src/components/Panels/Files.js
+++ b/src/components/Panels/Files.js
@@ -398,7 +398,8 @@ const FilesPanel = () => {
             currentFS,
             element.size == -1 ? "deletedir" : "delete",
             currentPath[currentFS],
-            element.name
+            element.name,
+            element.hasOwnProperty('dosname') ? element.dosname : element.name
         )
         if (cmd.type == "url") {
             sendURLCmd(cmd)
@@ -410,7 +411,8 @@ const FilesPanel = () => {
                     currentFS,
                     "delete",
                     processFeedback,
-                    element.name
+                    element.name,
+                    element.hasOwnProperty('dosname') ? element.dosname : element.name
                 )
             ) {
                 setIsLoading(true)
@@ -828,7 +830,8 @@ const FilesPanel = () => {
                                                                         currentPath[
                                                                             currentFS
                                                                         ],
-                                                                        line.name
+                                                                        line.name,
+                                                                        line.hasOwnProperty('dosname') ? line.dosname : line.name
                                                                     )
                                                                 sendSerialCmd(
                                                                     cmd.cmd

--- a/src/targets/Printer3D/Marlin/SD-source.js
+++ b/src/targets/Printer3D/Marlin/SD-source.js
@@ -44,6 +44,7 @@ const formatFileSerialLine = (lines) => {
                 ...acc,
                 {
                     name: pathAlt || path,
+                    dosname: path,
                     size: formatFileSizeToString(sizeAlt || size),
                 },
             ]
@@ -124,16 +125,16 @@ const commands = {
         res.status = formatStatus(data.status)
         return res
     },
-    play: (path, filename) => {
+    play: (path, filename, dosname) => {
         return {
             type: "cmd",
-            cmd: "M23 " + path + (path == "/" ? "" : "/") + filename + "\nM24",
+            cmd: "M23 " + path + (path == "/" ? "" : "/") + dosname + "\nM24",
         }
     },
-    delete: (path, filename) => {
+    delete: (path, filename, dosname) => {
         return {
             type: "cmd",
-            cmd: "M30 " + path + (path == "/" ? "" : "/") + filename,
+            cmd: "M30 " + path + (path == "/" ? "" : "/") + dosname,
         }
     },
 }

--- a/src/targets/Printer3D/Marlin/SDEXT-source.js
+++ b/src/targets/Printer3D/Marlin/SDEXT-source.js
@@ -44,6 +44,7 @@ const formatFileSerialLine = (lines) => {
                 ...acc,
                 {
                     name: pathAlt || path,
+                    dosname: path,
                     size: formatFileSizeToString(sizeAlt || size),
                 },
             ]
@@ -124,16 +125,16 @@ const commands = {
         res.status = formatStatus(data.status)
         return res
     },
-    play: (path, filename) => {
+    play: (path, filename, dosname) => {
         return {
             type: "cmd",
-            cmd: "M23 " + path + (path == "/" ? "" : "/") + filename + "\nM24",
+            cmd: "M23 " + path + (path == "/" ? "" : "/") + dosname + "\nM24",
         }
     },
-    delete: (path, filename) => {
+    delete: (path, filename, dosname) => {
         return {
             type: "cmd",
-            cmd: "M30 " + path + (path == "/" ? "" : "/") + filename,
+            cmd: "M30 " + path + (path == "/" ? "" : "/") + dosname,
         }
     },
 }

--- a/src/targets/Printer3D/Marlin/TFT-SD-source.js
+++ b/src/targets/Printer3D/Marlin/TFT-SD-source.js
@@ -167,7 +167,7 @@ const commands = {
         res.status = formatStatus(data.status)
         return res
     },
-    play: (path, filename) => {
+    play: (path, filename, dosname) => {
         if (useSettingsContextFn.getValue("SerialProtocol") != "MKS") {
             return {
                 type: "cmd",

--- a/src/targets/Printer3D/Marlin/TFT-USB-source.js
+++ b/src/targets/Printer3D/Marlin/TFT-USB-source.js
@@ -167,7 +167,7 @@ const commands = {
         res.status = formatStatus(data.status)
         return res
     },
-    play: (path, filename) => {
+    play: (path, filename, dosname) => {
         if (useSettingsContextFn.getValue("SerialProtocol") != "MKS") {
             return {
                 type: "cmd",


### PR DESCRIPTION
Marlin requires short 8.3 DOS names for all file handling commands. 

When Marlin uses MKS Serial protocol files are always listed with dosnames only, even with `M20 L` command. In order to [support displaying long filenames](https://github.com/MarlinFirmware/Marlin/pull/25483) and be able to print them ESP3D-WEBUI has to use both reported filenames: short one for issuing Print and Delete commands, and long ones, when available, to nicely display in file list panel.

This is draft PR that has not yet been tested.