### PR TITLE
Dbuezas/dont show print status in terminal

### DIFF
--- a/src/targets/Printer3D/Marlin/stream.js
+++ b/src/targets/Printer3D/Marlin/stream.js
@@ -18,12 +18,13 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 import { h } from "preact"
-import { isTemperatures, isPositions } from "./filters"
+import { isTemperatures, isPositions, isPrintStatus } from "./filters"
 
 const isVerboseOnly = (type, data) => {
     const line = data.trim()
     return isTemperatures(line) ||
         isPositions(line) ||
+        isPrintStatus(line) ||
         line.trim().length === 0 ||
         line.startsWith("echo:") ||
         line.startsWith("ok") ||


### PR DESCRIPTION
Since there is already a print pane for print status, and it is convenient to add a poller for that, these messages could be filtered out from the terminal

Relates to https://github.com/luc-github/ESP3D/issues/972