### PR TITLE
Fix Persistent toasts

### DIFF
--- a/src/contexts/UiContext.js
+++ b/src/contexts/UiContext.js
@@ -111,8 +111,9 @@ const UiContextProvider = ({ children }) => {
     }
 
     const removeToast = (uids) => {
-        const removedIds = removeEntriesByIDs(toastsRef.current, uids)
-        setToasts([...removedIds])
+        const remainingIds = removeEntriesByIDs(toastsRef.current, uids)
+        toastsRef.current = remainingIds
+        setToasts([...remainingIds])
     }
 
     const addModal = (newModal) =>


### PR DESCRIPTION
When the tab is in the background for long enough, the timeouts pile up and then get all called at once. This resulted in in a stale toastsRef.current array.