### PR TITLE
Added noToast field for "cmd" extension messages

### DIFF
--- a/src/areas/index.js
+++ b/src/areas/index.js
@@ -153,10 +153,12 @@ const ContentContainer = () => {
                                     )
                             },
                             onFail: (error) => {
-                                toasts.addToast({
-                                    content: error,
-                                    type: "error",
-                                })
+                                if (!eventMsg.data.noToast) {
+                                    toasts.addToast({
+                                        content: error,
+                                        type: "error",
+                                    })
+                                }
                                 console.log(error)
                                 if (!eventMsg.data.noDispatch)
                                     dispatchToExtensions(
@@ -217,10 +219,12 @@ const ContentContainer = () => {
                                     )
                             },
                             onFail: (error) => {
-                                toasts.addToast({
-                                    content: error,
-                                    type: "error",
-                                })
+                                if (!eventMsg.data.noToast) {
+                                    toasts.addToast({
+                                        content: error,
+                                        type: "error",
+                                    })
+                                }
                                 if (!eventMsg.data.noDispatch)
                                     dispatchToExtensions(
                                         "upload",
@@ -265,10 +269,12 @@ const ContentContainer = () => {
                                     )
                             },
                             onFail: (error) => {
-                                toasts.addToast({
-                                    content: error,
-                                    type: "error",
-                                })
+                                if (!eventMsg.data.noToast) {
+                                    toasts.addToast({
+                                        content: error,
+                                        type: "error",
+                                    })
+                                }
                                 if (!eventMsg.data.noDispatch)
                                     dispatchToExtensions(
                                         "download",

--- a/src/areas/index.js
+++ b/src/areas/index.js
@@ -108,10 +108,12 @@ const ContentContainer = () => {
                                     )
                             },
                             onFail: (error) => {
-                                toasts.addToast({
-                                    content: error,
-                                    type: "error",
-                                })
+                                if (!eventMsg.data.noToast) {
+                                    toasts.addToast({
+                                        content: error,
+                                        type: "error",
+                                    })
+                                }
                                 console.log(error)
                                 if (!eventMsg.data.noDispatch)
                                     dispatchToExtensions(


### PR DESCRIPTION
If eventMsg.data contains ".noToast" with a true value and the command results in an error, the error message toast will be suppressed.  That lets the extension handle errors internally without the user seeing a possibly-confusing message.

One use case is when the extension needs to issue a command that might not exist in older versions of the controller firmware, handling the error quietly for backwards compatibility.