### PR TITLE
Fix: Navbar clipping outside of viewport on mobile

### DIFF
--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -102,6 +102,15 @@ const Navbar = () => {
                 .click()
         }
     }
+
+    /*
+    auto-scroll textarea into view if mobile keyboard is blocking textarea to prevent
+    page resize and navbar from snapping out of viewport due to using fixed heights
+    */
+    window.visualViewport?.addEventListener("resize", () => {
+        window.scrollTo(0, 0);
+    });
+
     const disconnectNow = () => {
         const formData = new FormData()
         formData.append("DISCONNECT", "YES")


### PR DESCRIPTION
Fixed navbar snapping out of Viewport when <textarea> is being overlapped by virtual keyboard.

This implementation auto-scrolls the textarea into a viewable position before letting the user input text